### PR TITLE
Add Pages plugin mechanism to be able to add ChatGPT buttons to labels.

### DIFF
--- a/commons/bundle/src/main/java/com/composum/pages/commons/model/AbstractModel.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/model/AbstractModel.java
@@ -10,6 +10,7 @@ import com.composum.pages.commons.model.properties.Language;
 import com.composum.pages.commons.model.properties.Languages;
 import com.composum.pages.commons.request.DisplayMode;
 import com.composum.pages.commons.service.PageManager;
+import com.composum.pages.commons.service.PagesPluginService;
 import com.composum.pages.commons.service.ResourceManager;
 import com.composum.pages.commons.service.SiteManager;
 import com.composum.pages.commons.service.VersionsService;
@@ -105,6 +106,7 @@ public abstract class AbstractModel implements SlingBean, Model {
      */
     private transient ResourceManager resourceManager;
     private transient VersionsService versionsService;
+    private transient PagesPluginService pagesPluginService;
 
     // instance attributes
 
@@ -830,6 +832,14 @@ public abstract class AbstractModel implements SlingBean, Model {
             versionsService = Objects.requireNonNull(context.getService(VersionsService.class));
         }
         return versionsService;
+    }
+
+    @Nonnull
+    public PagesPluginService getPagesPluginService() {
+        if (pagesPluginService == null) {
+            pagesPluginService = Objects.requireNonNull(context.getService(PagesPluginService.class));
+        }
+        return pagesPluginService;
     }
 
     // Object

--- a/commons/bundle/src/main/java/com/composum/pages/commons/service/PagesPlugin.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/service/PagesPlugin.java
@@ -1,0 +1,28 @@
+package com.composum.pages.commons.service;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Interface with which plugins can register themselves.
+ */
+public interface PagesPlugin {
+
+    /**
+     * For ordering the plugins - high values are loaded later as in OSGI rank.
+     */
+    int getRank();
+
+    /**
+     * Returns a list of resourcetypes which provide extensions for widget labels.
+     * For each widget, the resource is to be rendered with these resource types when the widget label is added,
+     * so that we can add icons / buttons to the label.
+     */
+    @Nonnull
+    default List<String> getWidgetLabelExtensions() {
+        return Collections.emptyList();
+    }
+
+}

--- a/commons/bundle/src/main/java/com/composum/pages/commons/service/PagesPluginService.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/service/PagesPluginService.java
@@ -1,0 +1,20 @@
+package com.composum.pages.commons.service;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A service that collects PagesPlugins so that they could hook into Pages.
+ */
+public interface PagesPluginService {
+
+    /**
+     * Returns a list of resourcetypes which provide extensions for widget labels, collected from the plugins.
+     * For each widget, the resource is to be rendered with these resource types when the widget label is added,
+     * so that we can add icons / buttons to the label.
+     */
+    @Nonnull
+    List<String> getWidgetLabelExtensions();
+
+}

--- a/commons/bundle/src/main/java/com/composum/pages/commons/service/impl/PagesPluginServiceImpl.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/service/impl/PagesPluginServiceImpl.java
@@ -1,0 +1,77 @@
+package com.composum.pages.commons.service.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import org.jetbrains.annotations.NotNull;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.composum.pages.commons.service.PagesPlugin;
+import com.composum.pages.commons.service.PagesPluginService;
+
+/**
+ * A service that collects PagesPlugins so that they could hook into Pages.
+ */
+// FIXME(hps,27.04.23) How could we make sure that user packages cannot install a plugin for security?
+@Component(service = PagesPluginService.class, immediate = true)
+public class PagesPluginServiceImpl implements PagesPluginService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PagesPluginServiceImpl.class);
+
+    protected volatile List<PagesPlugin> pagesPlugins = Collections.emptyList();
+
+    // lazily computed values
+    protected volatile List<String> widgetLabelExtensions;
+
+    @Reference(
+            service = PagesPlugin.class,
+            policy = ReferencePolicy.DYNAMIC,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policyOption = ReferencePolicyOption.GREEDY
+    )
+    protected synchronized void bindPagesPlugin(@NotNull final PagesPlugin plugin) {
+        List<PagesPlugin> newPagesPlugins = new ArrayList<>(pagesPlugins);
+        newPagesPlugins.add(plugin);
+        newPagesPlugins.sort(Comparator.comparingInt(PagesPlugin::getRank));
+        pagesPlugins = Collections.unmodifiableList(newPagesPlugins);
+        LOG.info("Added PagesPlugin: {}", plugin);
+        resetLazyVariables();
+    }
+
+    /**
+     * Reset lazily computed values whenever a new plugin appears / one disappears.
+     */
+    protected void resetLazyVariables() {
+        widgetLabelExtensions = null;
+    }
+
+    protected synchronized void unbindPagesPlugin(@NotNull final PagesPlugin plugin) {
+        pagesPlugins = pagesPlugins.stream().filter(p -> p != plugin).collect(Collectors.toList());
+        LOG.info("Removed PagesPlugin: {}", plugin);
+        resetLazyVariables();
+    }
+
+    @Nonnull
+    public List<String> getWidgetLabelExtensions() {
+        if (widgetLabelExtensions == null) {
+            widgetLabelExtensions = Collections.unmodifiableList(
+                    pagesPlugins.stream()
+                            .flatMap(plugin -> plugin.getWidgetLabelExtensions().stream())
+                            .collect(Collectors.toList())
+            );
+        }
+        return widgetLabelExtensions;
+    }
+
+}

--- a/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/label.jsp
+++ b/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/label.jsp
@@ -5,4 +5,4 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <cpp:defineFrameObjects/>
 <c:if test="${widget.hasLabel}"><label class="control-label ${widgetCSS}_label"><span
-        class="label-text">${cpn:text(widget.label)}</span><sling:call script="hint.jsp"/></label></c:if>
+        class="label-text">${cpn:text(widget.label)}</span><sling:call script="labelextension.jsp"/><sling:call script="hint.jsp"/></label></c:if>

--- a/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/labelextension.jsp
+++ b/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/labelextension.jsp
@@ -1,0 +1,8 @@
+<%@page session="false" pageEncoding="UTF-8" %>
+<%-- Hook for extensions (buttons etc.) within the label. --%>
+<%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%--@elvariable id="widget" type="com.composum.pages.commons.taglib.AbstractWidgetTag"--%>
+<c:forEach items="${widget.model.pagesPluginService.widgetLabelExtensions}" var="extension">
+    <sling:include resourceType="${extension}"/>
+</c:forEach>


### PR DESCRIPTION
Since we need to hook into the widgets for the https://github.com/ist-dresden/composum-chatgpt-integration , I added a plugin mechanism for Pages. Currently it just allows to add extensions into widget labels. That could look like in the attached screenshot - there are buttons for translating from other languages, for content creation and suggesting categories.