### PR TITLE
Extend Pages tools mechanism to be able to add ChatGPT buttons to labels. 

### DIFF
--- a/PagesDevelopmentHowto.md
+++ b/PagesDevelopmentHowto.md
@@ -1,0 +1,21 @@
+# Some hints for developers of pages
+
+This is a wild collection of hints how to do things when extending Pages itself, developing components etc., in no
+particular order.
+This is not about how to use Composum Pages.
+
+## Client libraries
+
+Consult http://localhost:9090/system/console/clientlibs to get an overview what is there, find categories etc., and
+find examples where libraries are defined and declared and of js / css files.
+
+## Pages Dialogs
+
+Entry point for many dialogs:
+pages/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
+
+## Extensions to pages
+
+Compare ToolsCollection and classes using that: provide a collection with
+resource type <code>composum/pages/tools/collection</code>) with children that declare that extension. Compare class
+comment in ToolsCollection.

--- a/commons/bundle/src/main/java/com/composum/pages/commons/taglib/AbstractEditTag.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/taglib/AbstractEditTag.java
@@ -49,7 +49,7 @@ public abstract class AbstractEditTag extends AbstractFormTag {
      * Determines the resource to edit by the form of the dialog to create by this tag. This resource is mainly
      * determined by a 'EDIT_RESOURCE_KEY' request attribute which is declared by the edit servlet during the dialog
      * load request; if the dialog is loaded by a dialog component URL the edit resource is expected as the URLs suffix.
-     * Dialogs to ceate a new resourceshould be marked with a '*' resourcePath attribute to avoid copying of
+     * Dialogs to create a new resource should be marked with a '*' resourcePath attribute to avoid copying of
      * parent properties.
      *
      * @param context the current request context

--- a/commons/bundle/src/main/java/com/composum/pages/commons/widget/PathField.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/widget/PathField.java
@@ -17,7 +17,6 @@ public class PathField extends PropertyEditHandle<String> implements WidgetModel
         super(String.class);
     }
 
-    @Nonnull
     public String getPath() {
         return getValue();
     }

--- a/commons/bundle/src/main/resources/META-INF/cppl.tld
+++ b/commons/bundle/src/main/resources/META-INF/cppl.tld
@@ -791,6 +791,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>The title of the item.</description>
             <name>title</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
@@ -803,12 +804,14 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
+            <description>The rendered resource.</description>
             <name>resource</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
             <type>org.apache.sling.api.resource.Resource</type>
         </attribute>
         <attribute>
+            <description>The path of the resource to edit; if it ends with * then the dialog is meant to create a new resource.</description>
             <name>resourcePath</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -891,18 +894,21 @@
         <tei-class>com.composum.pages.commons.taglib.EditDialogTabTagTEI</tei-class>
         <body-content>JSP</body-content>
         <attribute>
+            <description>identifier of the tab</description>
             <name>tabId</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>the label of the tab</description>
             <name>label</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>can be used to disable the tab</description>
             <name>disabled</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -927,12 +933,14 @@
         <tei-class>com.composum.pages.commons.taglib.EditDialogGroupTagTEI</tei-class>
         <body-content>JSP</body-content>
         <attribute>
+            <description>an identifier for the group</description>
             <name>groupId</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>the label of the group</description>
             <name>label</name>
             <required>true</required>
             <rtexprvalue>true</rtexprvalue>
@@ -945,6 +953,7 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
+            <description>can be used to disable the group</description>
             <name>disabled</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -1226,6 +1235,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>The title of the item.</description>
             <name>title</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -1267,6 +1277,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>The title of the item.</description>
             <name>title</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -1315,6 +1326,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>The title of the item.</description>
             <name>title</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>
@@ -1356,6 +1368,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>The title of the item.</description>
             <name>title</name>
             <required>false</required>
             <rtexprvalue>true</rtexprvalue>

--- a/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/label.jsp
+++ b/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/label.jsp
@@ -5,4 +5,4 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <cpp:defineFrameObjects/>
 <c:if test="${widget.hasLabel}"><label class="control-label ${widgetCSS}_label"><span
-        class="label-text">${cpn:text(widget.label)}</span><sling:call script="hint.jsp"/></label></c:if>
+        class="label-text">${cpn:text(widget.label)}</span><sling:call script="labelextensions.jsp"/><sling:call script="hint.jsp"/></label></c:if>

--- a/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/labelextensions.jsp
+++ b/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/labelextensions.jsp
@@ -1,0 +1,14 @@
+<%@page session="false" pageEncoding="UTF-8" %><%--
+Hook for extensions (buttons etc.) within the label.
+--%><%@taglib prefix="sling" uri="http://sling.apache.org/taglibs/sling/1.2"
+%><%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"
+%><%@taglib prefix="cpn" uri="http://sling.composum.com/cpnl/1.0"
+%><cpn:defineObjects/><%--
+We include the labelextensions directly since some of the ChatGPT extensions have complicated visibility conditions.
+If needed, we could later also render icons directly here with the normal mechanism via tool.iconClass etc., when
+tool.resourceType is null.
+--%><cpn:component var="widgetTools" type="com.composum.pages.stage.tools.WidgetTools"><%--
+    --%><c:forEach var="tool" items="${widgetTools.labelExtensionComponentList}">
+        <sling:include resourceType="${tool.resourceType}"  replaceSelectors="labelextension" />
+    </c:forEach><%--
+--%></cpn:component>

--- a/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/multiwidget/multiwidget-simple.jsp
+++ b/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/multiwidget/multiwidget-simple.jsp
@@ -5,6 +5,6 @@
 <cpp:defineFrameObjects/>
 <div class="composum-pages-edit-multiwidget multiwidget-simple widget multi-form-widget form-group"
      data-name="${multiwidget.propertyName}">
-    <label class="control-label composum-pages-edit-multiwidget_label"><span class="label-text">${cpn:text(widget.label)}</span><sling:call script="hint.jsp"/></label>
+    <label class="control-label composum-pages-edit-multiwidget_label"><span class="label-text">${cpn:text(widget.label)}</span><sling:call script="labelextensions.jsp"/><sling:call script="hint.jsp"/></label>
     <div class="multi-form-content">
         <div class="multi-form-item">

--- a/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/textfield/textfield.jsp
+++ b/commons/package/src/main/content/jcr_root/libs/composum/pages/commons/widget/textfield/textfield.jsp
@@ -5,6 +5,7 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <cpp:defineFrameObjects/>
 <div class="${widgetCSS}_${widget.widgetType} ${widgetCSS}_${widget.cssName}${widget.required?' required':''} form-group">
+    <%--@elvariable id="widget" type="com.composum.pages.commons.taglib.EditWidgetTag"--%>
     <sling:call script="label.jsp"/>
     <c:if test="${!widget.blankAllowed&&widget.slingPost}">
         <input type="hidden" class="sling-post-hint" name="${widget.name}@Delete" value="true"/>

--- a/stage/bundle/src/main/java/com/composum/pages/stage/tools/ToolsCollection.java
+++ b/stage/bundle/src/main/java/com/composum/pages/stage/tools/ToolsCollection.java
@@ -17,6 +17,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Finds all tools represented as {@link ToolsCollection.Component} from collections (with resource type <code>composum/pages/tools/collection</code>) that have a {@value #CATEGORIES} attribute that has all categories from our categories, as given in the constructor {@link #ToolsCollection(BeanContext, Resource, List)}.
+ * The tool can also impose {@value #CONDITION} site or page that have to be met by the targetResource.
+ */
 public class ToolsCollection {
 
     public static final String CATEGORIES = "categories";

--- a/stage/bundle/src/main/java/com/composum/pages/stage/tools/ToolsCollection.java
+++ b/stage/bundle/src/main/java/com/composum/pages/stage/tools/ToolsCollection.java
@@ -18,7 +18,10 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Finds all tools represented as {@link ToolsCollection.Component} from collections (with resource type <code>composum/pages/tools/collection</code>) that have a {@value #CATEGORIES} attribute that has all categories from our categories, as given in the constructor {@link #ToolsCollection(BeanContext, Resource, List)}.
+ * Finds all tools represented as {@link ToolsCollection.Component} from collections
+ * (with resource type <code>composum/pages/tools/collection</code>) that have
+ * a {@value #CATEGORIES} attribute that has all categories from our categories,
+ * as given in the constructor {@link #ToolsCollection(BeanContext, Resource, List)}.
  * The tool can also impose {@value #CONDITION} site or page that have to be met by the targetResource.
  */
 public class ToolsCollection {
@@ -80,6 +83,13 @@ public class ToolsCollection {
 
         public int getOrder() {
             return values.get("order", 1);
+        }
+
+        /**
+         * If set, the current resource should be rendered with this resourceType, as opposed to rendering resource at our {@link #getPath()} with our sling:resourceType.
+         */
+        public String getResourceType() {
+            return values.get("resourceType", null);
         }
 
         @Override

--- a/stage/bundle/src/main/java/com/composum/pages/stage/tools/WidgetTools.java
+++ b/stage/bundle/src/main/java/com/composum/pages/stage/tools/WidgetTools.java
@@ -1,0 +1,37 @@
+package com.composum.pages.stage.tools;
+
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+
+import com.composum.pages.commons.model.AbstractModel;
+import com.composum.pages.commons.request.DisplayMode;
+import com.composum.sling.core.BeanContext;
+
+/**
+ * Integration point for extensions that add e.g. buttons to a widget.
+ */
+public class WidgetTools extends AbstractModel {
+
+    public static final String WIDGET_CATEGORY = "widget";
+
+    private transient ToolsCollection tools;
+
+    @Override
+    public void initialize(BeanContext context, final Resource resource) {
+        super.initialize(context, resource);
+    }
+
+    protected ToolsCollection getLabelTools() {
+        if (tools == null) {
+            tools = new ToolsCollection(context, null, WIDGET_CATEGORY, "label",
+                    DisplayMode.requested(context).name().toLowerCase());
+        }
+        return tools;
+    }
+
+    public List<ToolsCollection.Component> getLabelExtensionComponentList() {
+        return getLabelTools().getComponentList();
+    }
+
+}

--- a/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
+++ b/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
@@ -146,8 +146,19 @@
                 }
             }
         });
+        /** List where plugins can register themselves. Each should offer the method dialogInitializeView(dialog, element). */
+        dialogs.const.dialogplugins = dialogs.const.dialogplugins || [];
 
         dialogs.ElementDialog = core.components.FormDialog.extend({
+
+            initView: function () {
+                core.components.FormDialog.prototype.initView.apply(this);
+                for (const plugin of dialogs.const.dialogplugins) {
+                    if (_.isFunction(plugin.dialogInitializeView)) {
+                        plugin.dialogInitializeView(this, this.$el);
+                    }
+                }
+            },
 
             initSubmit: function () {
                 var c = dialogs.const.edit.css;
@@ -394,6 +405,7 @@
         dialogs.CreateDialog = dialogs.EditDialog.extend({
 
             initView: function () {
+                dialogs.ElementDialog.prototype.initView.apply(this);
                 this.initTabs();
             },
 
@@ -441,6 +453,7 @@
         dialogs.NewElementDialog = dialogs.ElementDialog.extend({
 
             initView: function () {
+                dialogs.ElementDialog.prototype.initView.apply(this);
                 this.elementType = core.getWidget(this.el, '.element-type-select-widget',
                     pages.widgets.ElementTypeSelectWidget, {
                         callback: _.bind(this.showOrDefault, this)
@@ -708,6 +721,7 @@
         dialogs.EditSourceFileDialog = dialogs.EditDialog.extend({
 
             initView: function () {
+                dialogs.EditDialog.extend.prototype.initView.apply(this);
                 var c = dialogs.const.edit.css;
                 dialogs.EditDialog.prototype.initView.apply(this);
                 this.$title = this.$('.modal-title');


### PR DESCRIPTION
Reimplementation replacing https://github.com/ist-dresden/composum-pages/pull/72 : this uses the existing ToolsCollection mechanism instead rolling your own service.

We introduce WidgetTools that are rendered into icons in the widget labels. Since the ChatGPT tools this was needed for do have in part some complicated visibility conditions the ToolsCollection.Component got a resourceType attribute, and the labelextensions.jsp renders the edited resource with that resourceType.