### PR TITLE
Display all sites in site manager if requested, not only of the users tenant

### DIFF
--- a/commons/bundle/src/main/java/com/composum/pages/commons/model/Sites.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/model/Sites.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 public class Sites extends AbstractModel {
 
+    public static final String PARAM_ALLSITES = "allSites";
+
     private transient Map<String, String> tenants;
     private transient Collection<Site> sites;
     private transient Collection<Site> templates;
@@ -37,7 +39,11 @@ public class Sites extends AbstractModel {
 
     public Collection<Site> getSites() {
         if (sites == null) {
-            sites = getSiteManager().getSites(context);
+            if (Boolean.TRUE.equals(Boolean.valueOf(getContext().getRequest().getParameter(PARAM_ALLSITES)))) {
+                sites = getSiteManager().getAllSites(context);
+            } else {
+                sites = getSiteManager().getSites(context);
+            }
         }
         return sites;
     }

--- a/commons/bundle/src/main/java/com/composum/pages/commons/service/PagesSiteManager.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/service/PagesSiteManager.java
@@ -242,6 +242,12 @@ public class PagesSiteManager extends PagesContentManager<Site> implements SiteM
         return sites;
     }
 
+    @NotNull
+    @Override
+    public Collection<Site> getAllSites(@NotNull BeanContext context) {
+        return getSites(context, getContentRoot(context.getResolver()), ResourceFilter.ALL);
+    }
+
     @Override
     public Collection<Site> getSiteTemplates(@Nonnull BeanContext context, String tenant) {
         UniqueSiteList result = new UniqueSiteList();

--- a/commons/bundle/src/main/java/com/composum/pages/commons/service/SiteManager.java
+++ b/commons/bundle/src/main/java/com/composum/pages/commons/service/SiteManager.java
@@ -138,6 +138,18 @@ public interface SiteManager extends ContentManager<Site> {
     @Nonnull
     Collection<Site> getSites(@Nonnull BeanContext context, @Nullable Resource searchRoot, @Nonnull ResourceFilter filter);
 
+
+    /**
+     * Determines all sites readable for the user, no matter what tenant.
+     *
+     * @param context the current request context
+     * @return the collection of all sites readable for the user
+     */
+    @Nonnull
+    default Collection<Site> getAllSites(@Nonnull BeanContext context) {
+        return getSites(context);
+    }
+
     /**
      * Determines all usable site templates in the context of a specific tenant.
      * This implementation uses the resolvers search path to find all site resources in a tenants application context.

--- a/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/css/dialogs.scss
+++ b/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/css/dialogs.scss
@@ -250,6 +250,18 @@
                 }
             }
         }
+
+        &_label_allsites {
+            display: flex;
+            align-items: center;
+            margin-left: $bootstrap-spacing-h;
+
+            span {
+                padding-top: 2px;
+                margin-left: 10px;
+            }
+        }
+
     }
 }
 

--- a/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/default/site/dialog/manage/manage.jsp
+++ b/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/default/site/dialog/manage/manage.jsp
@@ -1,8 +1,10 @@
 <%@page session="false" pageEncoding="utf-8" %>
 <%@taglib prefix="cpp" uri="http://sling.composum.com/cppl/1.0" %>
 <%@taglib prefix="cpn" uri="http://sling.composum.com/cpnl/1.0" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <cpp:defineFrameObjects/>
 <cpp:editDialog var="sites" type="com.composum.pages.commons.model.Sites" selector="custom" title="Manage Sites">
+    <%--@elvariable id="sites" type="com.composum.pages.commons.model.Sites"--%>
     <div class="modal-header ${dialogCssBase}_header">
         <button type="button" class="${dialogCssBase}_button-close fa fa-close"
                 data-dismiss="modal" aria-label="Close"></button>
@@ -32,6 +34,13 @@
         <button type="button" class="${dialogCssBase}_button-clone ${dialogCssBase}_button btn btn-default has-icon"
                 data-dismiss="modal" title="${cpn:i18n(slingRequest,'Clone Site')}"><i
                 class="${dialogCssBase}_icon fa fa-clone"></i>${cpn:i18n(slingRequest,'Clone')}</button>
+        <c:if test="${sites.tenantSupport}">
+            <label class="${dialogCssBase}_label_allsites tools-title"
+                   title="${cpn:i18n(slingRequest,'Also show sites that are readable even if they do not belong to your tenant(s).')}">
+                <input type="checkbox" class="${dialogCssBase}_checkbox_allsites"/>
+                <span class="title-text">${cpn:i18n(slingRequest,'All Sites')}</span>
+            </label>
+        </c:if>
         <div class="${dialogCssBase}_hints"></div>
         <button type="button" class="${dialogCssBase}_button-cancel ${dialogCssBase}_button btn btn-default"
                 data-dismiss="modal">${cpn:i18n(slingRequest,'Close')}</button>

--- a/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
+++ b/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
@@ -119,6 +119,7 @@
                     _submitButton: '_button-submit',
                     _prevButton: '_button-prev',
                     _nextButton: '_button-next',
+                    _allsitesCheckbox: '_checkbox_allsites',
                     site: {
                         base: 'composum-pages-stage-site',
                         _tile: '_tile'
@@ -1199,6 +1200,8 @@
                 this.$('.' + c.base + c._removeButton).click(_.bind(this.onDelete, this));
                 this.$('.' + c.base + c._openButton).click(_.bind(this.onOpen, this));
                 this.$('.' + c.base + c._cloneButton).click(_.bind(this.onClone, this));
+                this.$allsitesCheckbox = this.$('.' + c.base + c._allsitesCheckbox);
+                this.$allsitesCheckbox.bind('change', _.bind(this.reloadContent, this));
                 this.initContent();
                 var id = '.SiteManager';
                 var e = pages.const.event;
@@ -1214,7 +1217,11 @@
             },
 
             reloadContent: function () {
-                core.ajaxGet(dialogs.const.edit.url.sites.list, {}, _.bind(function (content) {
+                let url = dialogs.const.edit.url.sites.list;
+                if (this.$allsitesCheckbox.is(':checked')) {
+                    url = url + "?allSites=true";
+                }
+                core.ajaxGet(url, {}, _.bind(function (content) {
                     this.$list.html(content);
                     this.initContent();
                 }, this));

--- a/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
+++ b/stage/package/src/main/content/jcr_root/libs/composum/pages/stage/edit/js/dialogs.js
@@ -1141,6 +1141,7 @@
                 this.submitForm(_.bind(function (result) {
                     pages.trigger('dialog.site.create', pages.const.event.site.created,
                         [new pages.Reference(result.name, result.path)]);
+                    pages.trigger('dialog.site.create', pages.const.event.site.select, [result.path]);
                 }, this));
             }
         });
@@ -1176,8 +1177,9 @@
 
             doSubmit: function () {
                 this.submitForm(_.bind(function (result) {
-                    pages.trigger('dialog.site.create', pages.const.event.site.created,
+                    pages.trigger('dialog.site.clone', pages.const.event.site.created,
                         [new pages.Reference(result.name, result.path)]);
+                    pages.trigger('dialog.site.clone', pages.const.event.site.select, [result.path]);
                 }, this));
             }
         });


### PR DESCRIPTION
Adds a checkbox "All Sites" to the manage sites dialog to allow displaying (and especially cloning) all sites that are readable for the user, not only the ones of the users tenant.

Also, a created or cloned site is immediately opened.